### PR TITLE
Conditional API requests - rfc7232

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -199,16 +199,9 @@ paths:
       tags:
         - CORS
       description: List
-      parameters:
-        - in: header
-          name: If-Match
-          schema:
-            $ref: "#/components/headers/If-Match"
       responses:
         "204":
           $ref: "#/components/responses/Options"
-        "304":
-          $ref: "#/components/responses/NotModified"
   /users/{id}:
     parameters:
       - $ref: "#/components/parameters/id"
@@ -316,13 +309,6 @@ paths:
       tags:
         - CORS
       description: User
-      parameters:
-        - in: header
-          name: If-Match
-          schema:
-            $ref: "#/components/headers/If-Match"
       responses:
         "204":
           $ref: "#/components/responses/Options"
-        "304":
-          $ref: "#/components/responses/NotModified"

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -137,6 +137,11 @@ paths:
       tags:
         - Search
       summary: List of users
+      parameters:
+        - in: header
+          name: If-Match
+          schema:
+            $ref: "#/components/headers/If-Match"
       responses:
         "200":
           description: OK
@@ -160,6 +165,8 @@ paths:
                   },
                   { "id": 89, "name": "Jane Doe", "email": "jane@example.com" },
                 ]
+        "304":
+          $ref: "#/components/responses/NotModified"
     put:
       tags:
         - Edit
@@ -187,14 +194,21 @@ paths:
         "400":
           $ref: "#/components/responses/BadRequest"
         "415":
-          $ref:  "#/components/responses/UnsupportedMediaType"
+          $ref: "#/components/responses/UnsupportedMediaType"
     options:
       tags:
         - CORS
       description: List
+      parameters:
+        - in: header
+          name: If-Match
+          schema:
+            $ref: "#/components/headers/If-Match"
       responses:
         "204":
           $ref: "#/components/responses/Options"
+        "304":
+          $ref: "#/components/responses/NotModified"
   /users/{id}:
     parameters:
       - $ref: "#/components/parameters/id"
@@ -202,6 +216,11 @@ paths:
       tags:
         - Search
       summary: Display individual user
+      parameters:
+        - in: header
+          name: If-Match
+          schema:
+            $ref: "#/components/headers/If-Match"
       responses:
         "200":
           description: OK
@@ -223,6 +242,8 @@ paths:
                 $ref: "#/components/schemas/User"
               example:
                 { "id": 234, "name": "John Doe", "email": "john@example.com" }
+        "304":
+          $ref: "#/components/responses/NotModified"
         "404":
           $ref: "#/components/responses/NotFound"
     patch:
@@ -269,9 +290,9 @@ paths:
         "412":
           $ref: "#/components/responses/PreconditionFailed"
         "415":
-          $ref:  "#/components/responses/UnsupportedMediaType"
+          $ref: "#/components/responses/UnsupportedMediaType"
         "428":
-          $ref:  "#/components/responses/PreconditionRequired"
+          $ref: "#/components/responses/PreconditionRequired"
     delete:
       tags:
         - Edit
@@ -290,11 +311,18 @@ paths:
         "412":
           $ref: "#/components/responses/PreconditionFailed"
         "428":
-          $ref:  "#/components/responses/PreconditionRequired"
+          $ref: "#/components/responses/PreconditionRequired"
     options:
       tags:
         - CORS
       description: User
+      parameters:
+        - in: header
+          name: If-Match
+          schema:
+            $ref: "#/components/headers/If-Match"
       responses:
         "204":
           $ref: "#/components/responses/Options"
+        "304":
+          $ref: "#/components/responses/NotModified"

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -49,6 +49,8 @@ components:
     Error:
       $ref: "./schema/error.json"
   responses:
+    NotModified:
+      description: Not Modified
     NotFound:
       description: Not Found
       content:
@@ -67,6 +69,27 @@ components:
               value: { "error": "malformed JSON" }
             Schema Error:
               value: { "error": "schema was not respected." }
+    PreconditionFailed:
+      description: Precondition Failed
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          example: { "error": "the user was modified without your knowledge" }
+    PreconditionRequired:
+      description: Precondition Required
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          example: { "error": "an If-Match ETag must be provided" }
+    UnsupportedMediaType:
+      description: Unsupported Media Type
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+          example: { "error": "Content-Type must be application/json" }
     Options:
       description: Options
       headers:
@@ -95,6 +118,18 @@ components:
       schema:
         type: string
       description: Allowed number of seconds to cache the Preflight response.
+    Last-Modified:
+      schema:
+        type: string
+      description: Contains the date and time at which the origin server believes the resource was last modified.
+    ETag:
+      schema:
+        type: string
+      description: An identifier for a specific version of a resource
+    If-Match:
+      schema:
+        type: string
+      description: Makes the request conditional. The server will send back the requested resource only if it matches one of the listed ETags. For non-safe methods, it will only upload the resource in this case.
 
 paths:
   /users:
@@ -108,6 +143,10 @@ paths:
           headers:
             Access-Control-Allow-Origin:
               $ref: "#/components/headers/Access-Control-Allow-Origin"
+            Last-Modified:
+              $ref: "#/components/headers/Last-Modified"
+            ETag:
+              $ref: "#/components/headers/ETag"
           content:
             application/json:
               schema:
@@ -147,6 +186,8 @@ paths:
                 { "id": 234, "name": "John Doe", "email": "john@example.com" }
         "400":
           $ref: "#/components/responses/BadRequest"
+        "415":
+          $ref:  "#/components/responses/UnsupportedMediaType"
     options:
       tags:
         - CORS
@@ -165,8 +206,17 @@ paths:
         "200":
           description: OK
           headers:
+            Accept-Patch:
+              schema:
+                type: string
+                enum:
+                  - "application/json"
             Access-Control-Allow-Origin:
               $ref: "#/components/headers/Access-Control-Allow-Origin"
+            Last-Modified:
+              $ref: "#/components/headers/Last-Modified"
+            ETag:
+              $ref: "#/components/headers/ETag"
           content:
             application/json:
               schema:
@@ -179,6 +229,12 @@ paths:
       tags:
         - Edit
       summary: Edit an existing user
+      parameters:
+        - in: header
+          name: If-Match
+          schema:
+            $ref: "#/components/headers/If-Match"
+          required: true
       requestBody:
         description: edit any number of settings for a given user
         required: true
@@ -210,15 +266,31 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "404":
           $ref: "#/components/responses/NotFound"
+        "412":
+          $ref: "#/components/responses/PreconditionFailed"
+        "415":
+          $ref:  "#/components/responses/UnsupportedMediaType"
+        "428":
+          $ref:  "#/components/responses/PreconditionRequired"
     delete:
       tags:
         - Edit
       summary: Remove an existing user
+      parameters:
+        - in: header
+          name: If-Match
+          schema:
+            $ref: "#/components/headers/If-Match"
+          required: true
       responses:
         "204":
           description: No Content
         "404":
           $ref: "#/components/responses/NotFound"
+        "412":
+          $ref: "#/components/responses/PreconditionFailed"
+        "428":
+          $ref:  "#/components/responses/PreconditionRequired"
     options:
       tags:
         - CORS


### PR DESCRIPTION
[Hypertext Transfer Protocol (HTTP/1.1): Conditional Requests](https://tools.ietf.org/html/rfc7232)

This API will now support usage of `ETag` and `If-Match` for safe requests (for caching) and unsafe (to prevent mid-air collision)

This is also the addition of unsupported media type.