### PR TITLE
consuming packages with stricter ABI checks

### DIFF
--- a/.github/actions/setup-conan/action.yml
+++ b/.github/actions/setup-conan/action.yml
@@ -12,6 +12,10 @@ runs:
       shell: bash
     - run: conan config set general.revisions_enabled=1
       shell: bash
+    - run: conan config set general.full_transitive_package_id=1
+      shell: bash
+    - run: conan config set general.default_package_id_mode=full_version_mode
+      shell: bash
     - run: conan profile new default --detect
       shell: bash
     - run: conan profile update settings.compiler.libcxx=${{ inputs.libcxx }} default


### PR DESCRIPTION
> ⚠️ Just to trigger CI

Based on my reading from: 
- https://docs.conan.io/en/latest/versioning/lockfiles/introduction.html#locking-dependencies
- https://blog.conan.io/2019/09/27/package-id-modes.html
- https://docs.conan.io/en/latest/creating_packages/define_abi_compatibility.html#versioning-schema
- https://docs.conan.io/en/latest/creating_packages/define_abi_compatibility.html#changing-the-default-package-id-mode

_getting lost working on https://github.com/conan-io/docs/issues/1904_ 