### PR TITLE
Reuse back-end Alpine build image

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -40,7 +40,7 @@ jobs:
       name: docker.pkg.github.com/${{ github.repository }}/backend-build-alpine
     steps:
     - uses: actions/checkout@v2
-    - if: version
+    - id: version
       run: echo "::set-output name=version::$(echo ${{ hashFiles('backend/Dockerfile.build') }})"        
     - uses: docker/login-action@v1
       with:

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -108,7 +108,7 @@ jobs:
         fi
   
   list-deps:
-    needs: [setup, calc-deps]
+    needs: [calc-deps]
     runs-on: ubuntu-latest
     steps:
       - run: echo "${{ needs.calc-deps.outputs.empty_matrix }}"
@@ -120,7 +120,7 @@ jobs:
       - run: ls -R
 
   build-deps:
-    needs: [setup, calc-deps]
+    needs: [build-image, calc-deps]
     runs-on: ubuntu-latest
     container: 
       image: ${{ needs.build-image.outputs.name }}
@@ -159,7 +159,7 @@ jobs:
       - run: exit 0
   
   alpine-backend:
-    needs: [setup, build-deps]
+    needs: [build-image, build-deps]
     runs-on: ubuntu-latest
     container: 
       image: ${{ needs.build-image.outputs.name }}
@@ -188,7 +188,7 @@ jobs:
         run: conan upload "*" --all -r $CONAN_REMOTE -c
   
   backend-image:
-    needs: [setup, alpine-backend]
+    needs: [setup, build-image, alpine-backend]
     runs-on: ubuntu-latest
     container: 
       image: ${{ needs.build-image.outputs.name }}
@@ -404,7 +404,7 @@ jobs:
           docker push $DOCKER_REGISTRY/${{ matrix.image }}:${{ needs.setup.outputs.build-version }}
 
   deploy:
-    needs: [setup, upload]
+    needs: [upload]
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
     env: 

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -36,6 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
+      name: docker.pkg.github.com/${{ github.repository }}/backend-build-alpine:${{ steps.version.outputs.version }}
     env:
       name: docker.pkg.github.com/${{ github.repository }}/backend-build-alpine
     steps:
@@ -60,7 +61,7 @@ jobs:
     needs: [build-image]
     runs-on: ubuntu-latest
     container: 
-      image: docker.pkg.github.com/${{ github.repository }}/backend-build-alpine::${{ needs.build-image.outputs.version }}
+      image: docker.pkg.github.com/${{ github.repository }}/backend-build-alpine:${{ needs.build-image.outputs.version }}
       credentials:
         username: ${{ github.repository_owner }}
         password: ${{ github.token }}
@@ -68,6 +69,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       empty_matrix: ${{ steps.check-matrix.outputs.empty_matrix }}
     steps:
+    - run: echo "${{ needs.build-image.outputs.name }}"
     - uses: actions/checkout@v2
     - uses: actions/cache@v2
       with:

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master # tagged latest
+      - reuse-build-image
     tags:
       - v* # semver release
   pull_request: # runs tests
@@ -32,10 +33,11 @@ jobs:
         unique-alt-id: ${{ github.sha }}
 
   build-image:
-    needs: [setup]
     runs-on: ubuntu-latest
+    outputs:
+      build-image: ${{ steps.version.outputs.version }} 
     env:
-      name: docker.pkg.github.com/${{ github.repository }}/backend-build-alpine:${{ needs.setup.outputs.build-version }}
+      name: docker.pkg.github.com/${{ github.repository }}/backend-build-alpine:${{ hashFiles('backend/Dockerfile.build') }}
     steps:
     - uses: actions/checkout@v2
     - uses: docker/login-action@v1
@@ -43,14 +45,20 @@ jobs:
         registry: docker.pkg.github.com
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
-    - run: docker build . --file backend/Dockerfile.build --tag ${{ env.name }}
-    - run: docker push ${{ env.name }}
+    - if: check
+      name: check existence
+      run: |
+        docker pull ${{ env.name }} > /dev/null && echo "::set-output name=exists::$(echo true)" || echo "::set-output name=exists::$(echo false)"
+    - if: steps.check.outputs.exists == "false"
+      run: docker build . --file backend/Dockerfile.build --tag ${{ env.name }}
+    - if: steps.check.outputs.exists == "false"
+      run: docker push ${{ env.name }}
 
   calc-deps:
     needs: [setup, build-image]
     runs-on: ubuntu-latest
     container: 
-      image: docker.pkg.github.com/${{ github.repository }}/backend-build-alpine:${{ needs.setup.outputs.build-version }}
+      image: docker.pkg.github.com/${{ github.repository }}/backend-build-alpine:${{ hashFiles('backend/Dockerfile.build') }}
       credentials:
         username: ${{ github.repository_owner }}
         password: ${{ github.token }}

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -47,7 +47,7 @@ jobs:
         registry: docker.pkg.github.com
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
-    - if: check
+    - id: check
       name: check existence
       run: |
         docker pull ${{ env.name }}:${{ steps.version.outputs.version }} > /dev/null && echo "::set-output name=exists::$(echo true)" || echo "::set-output name=exists::$(echo false)"

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -67,12 +67,11 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       empty_matrix: ${{ steps.check-matrix.outputs.empty_matrix }}
     steps:
-    - run: echo "${{ needs.build-image.outputs.name }}"
     - uses: actions/checkout@v2
     - uses: actions/cache@v2
       with:
         path: ~/.conan/data
-        key: ${{ runner.os }}-${{ hashFiles('**/conan.lock') }}
+        key: apline-${{ hashFiles('**/conan.lock') }}
     - uses: ./.github/actions/setup-conan
     - name: calc
       run: |
@@ -106,18 +105,6 @@ jobs:
           echo "::set-output name=empty_matrix::false"        
         fi
   
-  list-deps:
-    needs: [calc-deps]
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "${{ needs.calc-deps.outputs.empty_matrix }}"
-      - run: echo "${{ needs.calc-deps.outputs.matrix }}"
-      - run: echo "${{ fromJson(needs.calc-deps.outputs.matrix) }}"
-      - uses: actions/download-artifact@v2
-        with:
-          name: conan-lockfile
-      - run: ls -R
-
   build-deps:
     needs: [build-image, calc-deps]
     runs-on: ubuntu-latest
@@ -134,7 +121,7 @@ jobs:
         if: ${{ matrix.reference != 'null' }}
         with:
           path: ~/.conan/data
-          key: ${{ runner.os }}-${{ hashFiles('**/conan.lock') }}
+          key: alpine-${{ hashFiles('**/conan.lock') }}
       - uses: ./.github/actions/setup-conan
         if: ${{ matrix.reference != 'null' }}
       - name: download
@@ -170,7 +157,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ~/.conan/data
-          key: ${{ runner.os }}-${{ hashFiles('**/conan.lock') }}
+          key: alpine-${{ hashFiles('**/conan.lock') }}
       - uses: actions/download-artifact@v2
         with:
           name: conan-lockfile
@@ -201,7 +188,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ~/.conan/data
-          key: ${{ runner.os }}-${{ hashFiles('**/conan.lock') }}
+          key: alpine-${{ hashFiles('**/conan.lock') }}
       - uses: actions/download-artifact@v2
         with:
           name: conan-lockfile

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master # tagged latest
-      - reuse-build-image
     tags:
       - v* # semver release
   pull_request: # runs tests

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -51,9 +51,9 @@ jobs:
       name: check existence
       run: |
         docker pull ${{ env.name }}:${{ steps.version.outputs.version }} > /dev/null && echo "::set-output name=exists::$(echo true)" || echo "::set-output name=exists::$(echo false)"
-    - if: steps.check.outputs.exists == "false"
+    - if: ${{ steps.check.outputs.exists == "false" }}
       run: docker build . --file backend/Dockerfile.build --tag ${{ env.name }}:${{ steps.version.outputs.version }}
-    - if: steps.check.outputs.exists == "false"
+    - if: ${{ steps.check.outputs.exists == "false" }}
       run: docker push ${{ env.name }}:${{ steps.version.outputs.version }}
 
   calc-deps:

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -51,9 +51,9 @@ jobs:
       name: check existence
       run: |
         docker pull ${{ env.name }}:${{ steps.version.outputs.version }} > /dev/null && echo "::set-output name=exists::$(echo true)" || echo "::set-output name=exists::$(echo false)"
-    - if: ${{ steps.check.outputs.exists == "false" }}
+    - if: ${{ steps.check.outputs.exists == 'false' }}
       run: docker build . --file backend/Dockerfile.build --tag ${{ env.name }}:${{ steps.version.outputs.version }}
-    - if: ${{ steps.check.outputs.exists == "false" }}
+    - if: ${{ steps.check.outputs.exists == 'false' }}
       run: docker push ${{ env.name }}:${{ steps.version.outputs.version }}
 
   calc-deps:

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -35,11 +35,13 @@ jobs:
   build-image:
     runs-on: ubuntu-latest
     outputs:
-      build-image: ${{ steps.version.outputs.version }} 
+      version: ${{ steps.version.outputs.version }}
     env:
-      name: docker.pkg.github.com/${{ github.repository }}/backend-build-alpine:${{ hashFiles('backend/Dockerfile.build') }}
+      name: docker.pkg.github.com/${{ github.repository }}/backend-build-alpine
     steps:
     - uses: actions/checkout@v2
+    - if: version
+      run: echo "::set-output name=version::$(echo ${{ hashFiles('backend/Dockerfile.build') }})"        
     - uses: docker/login-action@v1
       with:
         registry: docker.pkg.github.com
@@ -48,17 +50,17 @@ jobs:
     - if: check
       name: check existence
       run: |
-        docker pull ${{ env.name }} > /dev/null && echo "::set-output name=exists::$(echo true)" || echo "::set-output name=exists::$(echo false)"
+        docker pull ${{ env.name }}:${{ steps.version.outputs.version }} > /dev/null && echo "::set-output name=exists::$(echo true)" || echo "::set-output name=exists::$(echo false)"
     - if: steps.check.outputs.exists == "false"
-      run: docker build . --file backend/Dockerfile.build --tag ${{ env.name }}
+      run: docker build . --file backend/Dockerfile.build --tag ${{ env.name }}:${{ steps.version.outputs.version }}
     - if: steps.check.outputs.exists == "false"
-      run: docker push ${{ env.name }}
+      run: docker push ${{ env.name }}:${{ steps.version.outputs.version }}
 
   calc-deps:
-    needs: [setup, build-image]
+    needs: [build-image]
     runs-on: ubuntu-latest
     container: 
-      image: docker.pkg.github.com/${{ github.repository }}/backend-build-alpine:${{ hashFiles('backend/Dockerfile.build') }}
+      image: docker.pkg.github.com/${{ github.repository }}/backend-build-alpine::${{ needs.build-image.outputs.version }}
       credentials:
         username: ${{ github.repository_owner }}
         password: ${{ github.token }}

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -406,7 +406,6 @@ jobs:
   deploy:
     needs: [upload]
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
     env: 
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -414,20 +413,22 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: pulumi/action-install-pulumi-cli@v1.0.1
-      - run: |
-          cd .infra/
+      - name: test
+        working-directory: .infra/
+        run: |
           pulumi stack select dev
           npm install
           pulumi preview
-      - uses: pulumi/actions@v1.2.0
-        with:
-          command: up
-        env: 
-          PULUMI_ROOT: .infra/
-          PULUMI_STACK_NAME: dev
-      - name: report
+      - if: github.event_name == 'push'
+        name: deploy
+        working-directory: .infra/
         run: |
-          cd .infra/
+          pulumi stack select dev
+          pulumi up
+      - if: github.event_name == 'push'
+        name: report
+        working-directory: .infra/
+        run: |
           pulumi stack select dev
           jq -nc "{\"body\": \":rocket: automatically deployed to http://$(pulumi stack output url)\"}" | \
           curl -sL  -X POST -d @- \

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -424,7 +424,7 @@ jobs:
         working-directory: .infra/
         run: |
           pulumi stack select dev
-          pulumi up
+          pulumi up --yes
       - if: github.event_name == 'push'
         name: report
         working-directory: .infra/

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -35,7 +35,6 @@ jobs:
   build-image:
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.version.outputs.version }}
       name: docker.pkg.github.com/${{ github.repository }}/backend-build-alpine:${{ steps.version.outputs.version }}
     env:
       name: docker.pkg.github.com/${{ github.repository }}/backend-build-alpine
@@ -61,7 +60,7 @@ jobs:
     needs: [build-image]
     runs-on: ubuntu-latest
     container: 
-      image: docker.pkg.github.com/${{ github.repository }}/backend-build-alpine:${{ needs.build-image.outputs.version }}
+      image: ${{ needs.build-image.outputs.name }}
       credentials:
         username: ${{ github.repository_owner }}
         password: ${{ github.token }}
@@ -124,7 +123,7 @@ jobs:
     needs: [setup, calc-deps]
     runs-on: ubuntu-latest
     container: 
-      image: docker.pkg.github.com/${{ github.repository }}/backend-build-alpine:${{ needs.setup.outputs.build-version }}
+      image: ${{ needs.build-image.outputs.name }}
       credentials:
         username: ${{ github.repository_owner }}
         password: ${{ github.token }}
@@ -163,7 +162,7 @@ jobs:
     needs: [setup, build-deps]
     runs-on: ubuntu-latest
     container: 
-      image: docker.pkg.github.com/${{ github.repository }}/backend-build-alpine:${{ needs.setup.outputs.build-version }}
+      image: ${{ needs.build-image.outputs.name }}
       credentials:
         username: ${{ github.repository_owner }}
         password: ${{ github.token }}
@@ -192,7 +191,7 @@ jobs:
     needs: [setup, alpine-backend]
     runs-on: ubuntu-latest
     container: 
-      image: docker.pkg.github.com/${{ github.repository }}/backend-build-alpine:${{ needs.setup.outputs.build-version }}
+      image: ${{ needs.build-image.outputs.name }}
       credentials:
         username: ${{ github.repository_owner }}
         password: ${{ github.token }}
@@ -415,6 +414,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: pulumi/action-install-pulumi-cli@v1.0.1
+      - run: |
+          cd .infra/
+          pulumi stack select dev
+          pulumi preview
       - uses: pulumi/actions@v1.2.0
         with:
           command: up

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -417,6 +417,7 @@ jobs:
       - run: |
           cd .infra/
           pulumi stack select dev
+          npm install
           pulumi preview
       - uses: pulumi/actions@v1.2.0
         with:


### PR DESCRIPTION
building and pushing the build context takes ~2min, this cuts down on that waste

It will only be rebuilt if the Dockerfile changes... this will improve reproducibility across builds since they will all have exactly the same runtime

- use separate cache for build image
- preview the deploy in PR and "up" on push