### PR TITLE
Leverage installing `conan config` from a sub folder

### DIFF
--- a/.github/actions/setup-conan/action.yml
+++ b/.github/actions/setup-conan/action.yml
@@ -1,22 +1,11 @@
-name: 'Setup Conan'
-description: 'Install and configure the conan client'
-inputs:
-  libcxx:
-    description: 'C++ standard ABI version to use'
-    required: false
-    default: 'libstdc++11'
+name: "Setup Conan"
+description: "Install and configure the conan client for use in the user-management project's back-end"
 runs:
   using: "composite"
-  steps: 
+  steps:
     - run: python3 -m pip install conan --upgrade
       shell: bash
-    - run: conan config set general.revisions_enabled=1
+    - run: conan config init --force
       shell: bash
-    - run: conan config install backend/.conan/settings.yml
-      shell: bash
-    - run: conan profile new default --detect
-      shell: bash
-    - run: conan profile update settings.compiler.libcxx=${{ inputs.libcxx }} default
-      shell: bash
-    - run: conan remote list
+    - run: conan config install -t dir backend/.conan
       shell: bash

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -77,23 +77,18 @@ jobs:
         password: ${{ github.token }}
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
-      empty_matrix: ${{ steps.check-matrix.outputs.empty_matrix }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3
         with:
           path: ~/.conan/data
-          key: apline-${{ hashFiles('**/conan.lock') }}
+          key: alpine-${{ hashFiles('**/conan.lock') }}
       - uses: ./.github/actions/setup-conan
-      - name: calc
-        run: |
-          conan profile update settings.compiler.musl=1.2 default
-
-          cd backend
-          conan remote add $CONAN_REMOTE $CONAN_REMOTE_URL
-          conan user -p ${{ secrets.JFROG_RTFACT_PASSWORD }} -r $CONAN_REMOTE christopherm@jfrog.com
-
-          conan lock create conanfile.py --version $BUILD_VERSION --lockfile=conan.lock --lockfile-out=locks/conan.lock -s build_type=Release        
+      - run: conan user -p ${{ secrets.JFROG_RTFACT_PASSWORD }} -r $CONAN_REMOTE christopherm@jfrog.com
+      - name: build order
+        working-directory: backend
+        run: |          
+          conan lock create conanfile.py --version $BUILD_VERSION --lockfile=conan.lock --lockfile-out=locks/conan.lock -pr alpine-3-12 -s build_type=Release        
           conan lock build-order locks/conan.lock --json=build_order.json
       - uses: actions/upload-artifact@v3
         with:
@@ -108,14 +103,6 @@ jobs:
           MATRIX=$(cat matrix.json)
           echo "${MATRIX}"
           echo "::set-output name=matrix::${MATRIX}"
-      - id: check-matrix
-        name: Check matrix
-        run: |
-          if [[ ${{ steps.set-matrix.outputs.matrix }} == *"[]"* ]]; then
-            echo "::set-output name=empty_matrix::true"
-          else
-            echo "::set-output name=empty_matrix::false"        
-          fi
 
   build-deps:
     needs: [build-image, calc-deps]
@@ -129,8 +116,10 @@ jobs:
       matrix: ${{ fromJson(needs.calc-deps.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v3
-      - uses: ./.github/actions/setup-conan
-        if: ${{ matrix.reference != 'null' }}
+      - if: ${{ matrix.reference != 'null' }}
+        uses: ./.github/actions/setup-conan
+      - if: ${{ matrix.reference != 'null' }}
+        run: conan user -p ${{ secrets.JFROG_RTFACT_PASSWORD }} -r $CONAN_REMOTE christopherm@jfrog.com
       - name: download
         if: ${{ matrix.reference != 'null' }}
         uses: actions/download-artifact@v3
@@ -138,17 +127,10 @@ jobs:
           name: conan-lockfile
       - name: build
         if: ${{ matrix.reference != 'null' }}
-        run: |
-          conan profile update settings.compiler.musl=1.2 default
-
-          conan install ${{ matrix.reference }} -l conan.lock -b missing
+        run: conan install ${{ matrix.reference }} -l conan.lock -b missing
       - name: upload
         if: ${{ matrix.reference != 'null' }}
-        run: |
-          conan remote add $CONAN_REMOTE $CONAN_REMOTE_URL
-          conan user -p ${{ secrets.JFROG_RTFACT_PASSWORD }} -r $CONAN_REMOTE christopherm@jfrog.com
-
-          conan upload ${{ matrix.reference }} -r $CONAN_REMOTE --all
+        run: conan upload ${{ matrix.reference }} -r $CONAN_REMOTE --all
       - run: exit 0
 
   alpine-backend:
@@ -169,12 +151,7 @@ jobs:
         with:
           name: conan-lockfile
       - uses: ./.github/actions/setup-conan
-      - name: setup
-        run: |
-          conan profile update settings.compiler.musl=1.2 default
-
-          conan remote add $CONAN_REMOTE $CONAN_REMOTE_URL
-          conan user -p ${{ secrets.JFROG_RTFACT_PASSWORD }} -r $CONAN_REMOTE christopherm@jfrog.com
+      - run: conan user -p ${{ secrets.JFROG_RTFACT_PASSWORD }} -r $CONAN_REMOTE christopherm@jfrog.com
       - uses: ./.github/actions/replace-version
         with:
           new-version: ${{ env.BUILD_VERSION }}
@@ -204,13 +181,9 @@ jobs:
         with:
           name: conan-lockfile
       - uses: ./.github/actions/setup-conan
+      - run: conan user -p ${{ secrets.JFROG_RTFACT_PASSWORD }} -r $CONAN_REMOTE christopherm@jfrog.com
       - name: download
         run: |
-          conan profile update settings.compiler.musl=1.2 default
-
-          conan remote add $CONAN_REMOTE $CONAN_REMOTE_URL
-          conan user -p ${{ secrets.JFROG_RTFACT_PASSWORD }} -r $CONAN_REMOTE christopherm@jfrog.com
-
           conan install $NAME/$BUILD_VERSION@ -r $CONAN_REMOTE -l conan.lock -if backend
       - name: build
         run: |
@@ -252,15 +225,13 @@ jobs:
       - uses: ./.github/actions/setup-conan
       - uses: lukka/get-cmake@latest
       - name: build
+        working-directory: backend
         run: |
-          cd backend
-
           conan lock create conanfile.py --version $BUILD_VERSION --lockfile=conan.lock --lockfile-out=locks/conan.lock -s build_type=${{ matrix.build-type }} -s compiler.libcxx=libstdc++11 -o user-management:logging=${{ matrix.logging }}
           conan create conanfile.py $BUILD_VERSION@ --lockfile=locks/conan.lock
       - name: upload
         if: (github.event_name == 'push' || matrix.build-type == 'Release') && needs.check.outputs.permitted == 'true'
         run: |
-          conan remote add $CONAN_REMOTE $CONAN_REMOTE_URL
           conan user -p ${{ secrets.JFROG_RTFACT_PASSWORD }} -r $CONAN_REMOTE christopherm@jfrog.com
 
           conan upload $NAME/$BUILD_VERSION@ -r $CONAN_REMOTE --all
@@ -272,7 +243,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14.x # Current LTS
+          node-version: 16.x # Current LTS
       - uses: ./.github/actions/setup-rtfact-npm
         with:
           registry: ${{ env.NPM_REGISTRY_URL }}
@@ -386,6 +357,7 @@ jobs:
 
   upload:
     needs: [setup, test]
+    if: github.event_name == 'push'
     strategy:
       matrix:
         image:
@@ -403,7 +375,6 @@ jobs:
           registry: superfrogchrismc.jfrog.io
           username: christopherm@jfrog.com
           password: ${{ secrets.JFROG_RTFACT_PASSWORD }}
-      - if: github.event_name == 'push'
         name: push
         run: |
           docker pull $DOCKER_REGISTRY/${{ matrix.image }}:$BUILD_VERSION

--- a/backend/.conan/config/conan.conf
+++ b/backend/.conan/config/conan.conf
@@ -1,0 +1,2 @@
+[general]
+revisions_enabled = 1

--- a/backend/.conan/profiles/alpine-3-12
+++ b/backend/.conan/profiles/alpine-3-12
@@ -1,0 +1,9 @@
+include(default)
+
+[settings]
+os=Linux
+arch=x86_64
+compiler=gcc
+compiler.version=9
+compiler.libcxx=libstdc++11
+compiler.musl=1.2

--- a/backend/.conan/remotes.txt
+++ b/backend/.conan/remotes.txt
@@ -1,0 +1,2 @@
+conancenter https://center.conan.io true
+user-management https://superfrogchrismc.jfrog.io/artifactory/api/conan/user-management-conan true

--- a/backend/readme.md
+++ b/backend/readme.md
@@ -5,31 +5,29 @@
 ### Conan Configuration
 
 > :warning: This **must** be done before any usage!
-If that is not possible, you will need to clear your conan cache. This can be done using `conan remove -f '*'`
+> It assumes the default configutation is present. This can reset yours with `conan config init --force`.
+> Old packages in your local conan cache will become invalid. This can be cleared using `conan remove -f '*'`.
 
-Enable recipe revisions
+Install the extended settings model, setup the custom remote, and configure the necessary settings:
 
 ```sh
-conan config set general.revisions_enabled=1
+conan config install -t dir backend/.conan
 ```
 
 #### Targeting different `C` library implementations
 
-The Conan default `settings.yml` does not take these into account. The settings model can be extended by doing the following:
+The Conan default `settings.yml` does not take these into account. You will need to sign into the `user-management` remote that was installed
+with the configuration to download the pre-compiled binaries.
 
-1. install an extended settings model
-
-```sh
-conan config install .conan/settings.yml
-```
-
-2. configure your profile (or build settings)
+The settings model can be extended by configuring your default profile (or build settings)
 
 ```sh
 conan profile update settings.compiler.musl=1.2 default
 # or
 conan profile update settings.compiler.glibc=2.32 default
 ```
+
+For more option see [Profiles](https://docs.conan.io/en/latest/reference/profiles.html) documentation.
 
 ## Development
 
@@ -46,19 +44,21 @@ Build the project
 cmake --build . # from the build folder
 ```
 
+### Configuration Options
+
 Enable building tests
 
 ```sh
 cmake .. -DBUILD_TESTS=ON
 ```
 
-Enable building tests
+Enable running linters
 
 ```sh
 cmake .. -DRUN_TIDY=ON
 ```
 
-### Updating dependencies
+### Updating Dependencies
 
 To update the top level `conan.lock` run:
 
@@ -75,7 +75,7 @@ conan install conanfile.py --lockfile=build/conan.lock -if build
 
 ## Usage
 
-### Lock Dependency graph
+### Lock Dependency Graph
 
 ```sh
 conan lock create conanfile.py --version 1.0.0-dev.1+`git rev-parse --short HEAD` --lockfile=conan.lock --lockfile-out=locks/conan.lock


### PR DESCRIPTION
With the recent discovery of https://docs.conan.io/en/latest/reference/commands/consumer/config.html#conan-config-install I thought it would be worth cleaning up some of the duplicated CI steps

- [x] Update docs + describe new profile